### PR TITLE
fix: invisible git action icons

### DIFF
--- a/themes/windows-nt-color-theme.json
+++ b/themes/windows-nt-color-theme.json
@@ -722,7 +722,7 @@
     "peekViewResult.matchHighlightBackground": "#ea5c004d",
     "peekViewResult.selectionBackground": "#3399ff33",
     "peekViewResult.selectionForeground": "#6c6c6c",
-    "peekViewTitle.background": "#ffffff",
+    "peekViewTitle.background": "#c7c7c7",
     "peekViewTitleDescription.foreground": "#616161e6",
     "peekViewTitleLabel.foreground": "#333333",
     "icon.foreground": "#ffffff",


### PR DESCRIPTION
Hi! I really love the job you have done creating this awesome theme!
The only thing that is slightly inconvenient are the invisible git action icons in the peekView. I think the issue is best explained using screenshots:

Before:

![Before](https://user-images.githubusercontent.com/26383279/214084468-3c94efc4-43fd-450b-8439-160ba3eac31e.png)


After:

![after](https://user-images.githubusercontent.com/26383279/214084536-c24b5f8c-82cf-435d-9387-e3b1caaf4fd5.png)