### PR TITLE
fix: autocomplete widget contrast

### DIFF
--- a/themes/windows-nt-color-theme.json
+++ b/themes/windows-nt-color-theme.json
@@ -702,7 +702,7 @@
     "merge.incomingContentBackground": "#DBECFF",
     "merge.commonHeaderBackground": "#BFBFBF",
     "merge.commonContentBackground": "#E5E5E5",
-    "editorSuggestWidget.background": "#3c3c3c",
+    "editorSuggestWidget.background": "#c8c8c8",
     "editorSuggestWidget.border": "#c8c8c8",
     "editorSuggestWidget.foreground": "#000000",
     "editorSuggestWidget.highlightForeground": "#367B7B",


### PR DESCRIPTION
Hello again, i just found a minor contrast issue which makes the text in the autocomplete widget very hard to read:

before:

<img width="867" alt="Screenshot 2023-02-02 at 17 51 04" src="https://user-images.githubusercontent.com/26383279/216390524-265f5c3d-df4b-45ac-a78f-cee58618e347.png">

after:

<img width="864" alt="Screenshot 2023-02-02 at 17 50 38" src="https://user-images.githubusercontent.com/26383279/216390554-aa0a885c-fe88-4abb-aeec-cb5f20cea207.png">
